### PR TITLE
Fix missing round distance

### DIFF
--- a/stats.html
+++ b/stats.html
@@ -219,6 +219,7 @@
       putts: d.holes.reduce((a,h)=>a+(h.putts||0),0),
       courseRating: d.cr,
       slopeRating: d.slope,
+      totalDistance: d.totalDistance,
       combo: d.combo || false
     };
   });


### PR DESCRIPTION
## Summary
- include `totalDistance` when loading rounds for stats page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685964cd1db4832e96891fe07f1d3c54