### PR TITLE
Refactor club options to shared module

### DIFF
--- a/app.js
+++ b/app.js
@@ -7,6 +7,7 @@ import {
 } from "https://www.gstatic.com/firebasejs/9.23.0/firebase-auth.js";
 import { initFirebase, firebaseConfig } from './firebase-config.js';
 import { courses } from "./courses.js";
+import { clubs } from "./clubList.js";
 
 
 
@@ -148,8 +149,21 @@ function clearInputs() {
   document.getElementById("club").value = "";
 }
 
+function populateClubSelect() {
+  const sel = document.getElementById("club");
+  if (!sel) return;
+  sel.innerHTML = '<option value="">-- Seleziona --</option>';
+  clubs.forEach(c => {
+    const opt = document.createElement("option");
+    opt.value = c;
+    opt.textContent = c;
+    sel.appendChild(opt);
+  });
+}
+
 window.addEventListener("DOMContentLoaded", () => {
   populateCourseOptions();
+  populateClubSelect();
   document.getElementById("course").addEventListener("input", () => {
     updateLayoutOptions();
     updateComboOptions();

--- a/clubList.js
+++ b/clubList.js
@@ -1,0 +1,15 @@
+export const clubs = [
+  "Driver",
+  "3 Wood",
+  "5 Wood",
+  "3 Iron",
+  "4 Iron",
+  "5 Iron",
+  "6 Iron",
+  "7 Iron",
+  "8 Iron",
+  "9 Iron",
+  "Pitching Wedge",
+  "Sand Wedge",
+  "Lob Wedge"
+];

--- a/clubs.html
+++ b/clubs.html
@@ -75,19 +75,6 @@
     <label for="club-select">Bastone:</label>
     <select id="club-select">
       <option value="">-- Seleziona --</option>
-      <option>Driver</option>
-      <option>3 Wood</option>
-      <option>5 Wood</option>
-      <option>3 Iron</option>
-      <option>4 Iron</option>
-      <option>5 Iron</option>
-      <option>6 Iron</option>
-      <option>7 Iron</option>
-      <option>8 Iron</option>
-      <option>9 Iron</option>
-      <option>Pitching Wedge</option>
-      <option>Sand Wedge</option>
-      <option>Lob Wedge</option>
     </select>
 
     <label for="distance-input">Distanza (metri):</label>

--- a/clubs.js
+++ b/clubs.js
@@ -11,6 +11,7 @@ import {
   onAuthStateChanged
 } from "https://www.gstatic.com/firebasejs/9.23.0/firebase-auth.js";
 import { initFirebase } from './firebase-config.js';
+import { clubs } from './clubList.js';
 
 
 const { app, auth, db } = initFirebase();
@@ -135,3 +136,19 @@ window.saveClubShot = async function () {
     alert("Errore nel salvataggio: " + error.message);
   }
 }
+
+function populateClubSelect() {
+  const sel = document.getElementById("club-select");
+  if (!sel) return;
+  sel.innerHTML = '<option value="">-- Seleziona --</option>';
+  clubs.forEach(c => {
+    const opt = document.createElement("option");
+    opt.value = c;
+    opt.textContent = c;
+    sel.appendChild(opt);
+  });
+}
+
+window.addEventListener("DOMContentLoaded", () => {
+  populateClubSelect();
+});

--- a/index.html
+++ b/index.html
@@ -98,19 +98,6 @@
     <label for="club">Bastone utilizzato:</label>
     <select id="club">
       <option value="">-- Seleziona --</option>
-      <option>Driver</option>
-      <option>3 Wood</option>
-      <option>5 Wood</option>
-      <option>3 Iron</option>
-      <option>4 Iron</option>
-      <option>5 Iron</option>
-      <option>6 Iron</option>
-      <option>7 Iron</option>
-      <option>8 Iron</option>
-      <option>9 Iron</option>
-      <option>Pitching Wedge</option>
-      <option>Sand Wedge</option>
-      <option>Lob Wedge</option>
     </select>
 
     <label for="distanceShot">Distanza colpo (metri):</label>


### PR DESCRIPTION
## Summary
- centralize club names in `clubList.js`
- load club lists dynamically in `app.js` and `clubs.js`
- remove hard-coded options from HTML pages

## Testing
- `npm test` *(fails: could not find `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68597ca7efbc832eb6adbea57c946598