### PR TITLE
Add date range filters and fairway/GIR metrics

### DIFF
--- a/stats.html
+++ b/stats.html
@@ -76,6 +76,8 @@
       <select id="filter-course">
         <option value="all">Tutti i campi</option>
       </select>
+      <input type="date" id="start-date" />
+      <input type="date" id="end-date" />
     </label>
   </section>
 
@@ -97,6 +99,15 @@
   <section class="chart-container">
     <h2>% Putt sui colpi totali</h2>
     <canvas id="puttChart"></canvas>
+  </section>
+
+  <section class="chart-container">
+    <h2>Fairway e GIR</h2>
+    <canvas id="fwGirChart"></canvas>
+    <table id="fw-gir-table" style="margin-top:1rem;">
+      <thead><tr><th>Metric</th><th>%</th></tr></thead>
+      <tbody></tbody>
+    </table>
   </section>
 
   <section class="chart-container">


### PR DESCRIPTION
## Summary
- add start and end date pickers to stats page
- filter statistics by selected date range
- compute fairway hit and GIR percentages
- show these metrics in a new chart and table

## Testing
- `node -e "import('./stats.js').catch(e=>console.error(e.message))"` *(fails: Only URLs with a scheme in: file and data are supported by the default ESM loader)*

------
https://chatgpt.com/codex/tasks/task_e_685980b6d5e4832ebf3fd5637679b79a