### PR TITLE
Add course management via Firestore

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ navigation links.
 - **profile1.html** – manage your personal profile information stored in
   Firestore.
 - **round.html** – display the details of a saved round.
+- **admin.html** – create or edit course definitions stored in Firestore.
 
-The course definitions used by the round entry page are stored in
-`courses.js`; you can customise this file with your own course data.
+Course definitions are now stored in a Firestore collection and can be
+managed through **admin.html**.

--- a/admin.html
+++ b/admin.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="it">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Gestione Campi</title>
+  <link rel="stylesheet" href="styles.css" />
+  <style>
+    body {
+      padding: 1rem;
+      background: #f5f5f5;
+    }
+    form, #course-list {
+      max-width: 600px;
+      margin: 0 auto 2rem auto;
+    }
+    label {
+      display: block;
+      margin-top: 0.5rem;
+    }
+    input, textarea, button {
+      width: 100%;
+      padding: 0.5rem;
+      margin-top: 0.2rem;
+      box-sizing: border-box;
+    }
+    button {
+      margin-top: 0.5rem;
+    }
+    li button {
+      margin-left: 0.5rem;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Gestione Campi</h1>
+  </header>
+  <nav>
+    <a href="home.html">🏠 Home</a>
+  </nav>
+  <main class="container">
+    <form id="course-form">
+      <label for="course-name">Nome Campo</label>
+      <input id="course-name" type="text" />
+
+      <label for="course-data">Dati (JSON)</label>
+      <textarea id="course-data" rows="10"></textarea>
+
+      <button type="button" onclick="saveCourse()">Salva</button>
+    </form>
+
+    <h2>Campi esistenti</h2>
+    <ul id="course-list"></ul>
+  </main>
+
+  <script type="module" src="admin.js"></script>
+</body>
+</html>

--- a/admin.js
+++ b/admin.js
@@ -1,0 +1,74 @@
+import {
+  collection,
+  getDocs,
+  setDoc,
+  doc,
+  deleteDoc
+} from 'https://www.gstatic.com/firebasejs/9.23.0/firebase-firestore.js';
+import { onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/9.23.0/firebase-auth.js';
+import { initFirebase } from './firebase-config.js';
+
+const { auth, db } = initFirebase();
+let editingId = null;
+
+async function loadCourses() {
+  const snap = await getDocs(collection(db, 'courses'));
+  const list = document.getElementById('course-list');
+  list.innerHTML = '';
+  snap.forEach(docSnap => {
+    const li = document.createElement('li');
+    li.textContent = docSnap.id;
+    const edit = document.createElement('button');
+    edit.textContent = 'Modifica';
+    edit.onclick = () => editCourse(docSnap.id, docSnap.data());
+    const del = document.createElement('button');
+    del.textContent = 'Elimina';
+    del.onclick = () => deleteCourse(docSnap.id);
+    li.appendChild(edit);
+    li.appendChild(del);
+    list.appendChild(li);
+  });
+}
+
+function editCourse(id, data) {
+  editingId = id;
+  document.getElementById('course-name').value = id;
+  document.getElementById('course-data').value = JSON.stringify(data, null, 2);
+}
+
+async function deleteCourse(id) {
+  if (confirm('Eliminare il campo?')) {
+    await deleteDoc(doc(db, 'courses', id));
+    await loadCourses();
+  }
+}
+
+window.saveCourse = async function () {
+  const name = document.getElementById('course-name').value.trim();
+  if (!name) {
+    alert('Nome campo obbligatorio');
+    return;
+  }
+  let data = {};
+  const text = document.getElementById('course-data').value.trim();
+  if (text) {
+    try {
+      data = JSON.parse(text);
+    } catch (e) {
+      alert('JSON non valido');
+      return;
+    }
+  }
+  await setDoc(doc(db, 'courses', name), { ...data, name });
+  editingId = null;
+  document.getElementById('course-form').reset();
+  await loadCourses();
+};
+
+onAuthStateChanged(auth, user => {
+  if (!user) {
+    window.location.href = 'home.html';
+  } else {
+    loadCourses();
+  }
+});

--- a/app.js
+++ b/app.js
@@ -3,6 +3,7 @@ import {
   addDoc,
   setDoc,
   getDoc,
+  getDocs,
   deleteDoc,
   doc
 } from "https://www.gstatic.com/firebasejs/9.23.0/firebase-firestore.js";
@@ -10,7 +11,7 @@ import {
   onAuthStateChanged
 } from "https://www.gstatic.com/firebasejs/9.23.0/firebase-auth.js";
 import { initFirebase, firebaseConfig } from './firebase-config.js';
-import { courses } from "./courses.js";
+let courses = {};
 import { clubs } from "./clubList.js";
 
 
@@ -25,6 +26,14 @@ let totalHoles = 9;
 let selectedHoles = [];
 const roundData = [];
 const DRAFT_KEY = 'roundDraft';
+
+async function loadCourses() {
+  const snap = await getDocs(collection(db, 'courses'));
+  courses = {};
+  snap.forEach(docSnap => {
+    courses[docSnap.id] = docSnap.data();
+  });
+}
 
 onAuthStateChanged(auth, (user) => {
   if (user) {
@@ -247,6 +256,7 @@ async function checkForDraft() {
 }
 
 window.addEventListener("DOMContentLoaded", async () => {
+  await loadCourses();
   populateCourseOptions();
   populateClubSelect();
   document.getElementById("course").addEventListener("input", () => {

--- a/home.html
+++ b/home.html
@@ -70,6 +70,7 @@
       <a href="index.html">➕ Aggiungi nuovo Round</a>
       <a href="stats.html">📊 Statistiche Personali</a>
       <a href="profile1.html">👤 Il mio Profilo</a>
+      <a href="admin.html">⚙️ Gestisci Campi</a>
     </div>
   </main>
 


### PR DESCRIPTION
## Summary
- load courses from Firestore rather than local file
- add an admin page to manage courses
- link to the new admin page from the home screen
- document the new page and Firestore-based course storage

## Testing
- `node --check admin.js`
- `node --check app.js`

------
https://chatgpt.com/codex/tasks/task_e_685980b72a64832e8b3004d11133c1ab