### PR TITLE
Add Firestore club settings

### DIFF
--- a/app.js
+++ b/app.js
@@ -12,7 +12,8 @@ import {
 } from "https://www.gstatic.com/firebasejs/9.23.0/firebase-auth.js";
 import { initFirebase, firebaseConfig } from './firebase-config.js';
 let courses = {};
-import { clubs } from "./clubList.js";
+import { clubs as defaultClubs } from "./clubList.js";
+import { loadClubs } from "./userSettings.js";
 
 
 
@@ -27,6 +28,7 @@ let shotIndex = 0;
 let selectedHoles = [];
 const roundData = [];
 const DRAFT_KEY = 'roundDraft';
+let clubs = [...defaultClubs];
 
 async function loadCourses() {
   const snap = await getDocs(collection(db, 'courses'));
@@ -36,11 +38,14 @@ async function loadCourses() {
   });
 }
 
-onAuthStateChanged(auth, (user) => {
+onAuthStateChanged(auth, async (user) => {
   if (user) {
     uid = user.uid;
     userDisplayName = user.displayName;
     userEmail = user.email;
+
+    clubs = await loadClubs(uid);
+    document.querySelectorAll('.club-select').forEach(sel => populateClubSelect(sel));
 
     // Auto-riempi il campo player se è vuoto
     const playerInput = document.getElementById("player");
@@ -306,6 +311,9 @@ async function checkForDraft() {
 
 window.addEventListener("DOMContentLoaded", async () => {
   await loadCourses();
+  if (uid) {
+    clubs = await loadClubs(uid);
+  }
   populateCourseOptions();
   shotIndex = document.querySelectorAll('#shots-container .shot-row').length;
   if (shotIndex === 0) {

--- a/clubs.js
+++ b/clubs.js
@@ -11,15 +11,19 @@ import {
   onAuthStateChanged
 } from "https://www.gstatic.com/firebasejs/9.23.0/firebase-auth.js";
 import { initFirebase } from './firebase-config.js';
-import { clubs } from './clubList.js';
+import { clubs as defaultClubs } from './clubList.js';
+import { loadClubs } from './userSettings.js';
 
 
 const { app, auth, db } = initFirebase();
 let uid = null;
+let clubs = [...defaultClubs];
 
 onAuthStateChanged(auth, async (user) => {
   if (user) {
     uid = user.uid;
+    clubs = await loadClubs(uid);
+    populateClubSelect();
     await loadClubData();
   } else {
     window.location.href = "home.html";

--- a/profile.js
+++ b/profile.js
@@ -1,9 +1,12 @@
 import { onAuthStateChanged } from "https://www.gstatic.com/firebasejs/9.23.0/firebase-auth.js";
 import { doc, getDoc, setDoc } from "https://www.gstatic.com/firebasejs/9.23.0/firebase-firestore.js";
 import { initFirebase } from './firebase-config.js';
+import { loadClubs, saveClubs } from './userSettings.js';
+import { clubs as defaultClubs } from './clubList.js';
 
 const { auth, db } = initFirebase();
 let currentUid = null;
+let clubList = [...defaultClubs];
 
 onAuthStateChanged(auth, async (user) => {
   if (!user) {
@@ -21,6 +24,9 @@ onAuthStateChanged(auth, async (user) => {
     document.getElementById("email").value = data.email || "";
     document.getElementById("hcp").value = data.officialHandicap ?? "";
   }
+
+  clubList = await loadClubs(currentUid);
+  renderClubList();
 });
 
 window.saveProfile = async function () {
@@ -41,4 +47,40 @@ window.saveProfile = async function () {
   }, { merge: true });
 
   alert("Profilo aggiornato con successo!");
+}
+
+function renderClubList() {
+  const ul = document.getElementById('clubs-list');
+  if (!ul) return;
+  ul.innerHTML = '';
+  clubList.forEach((c, idx) => {
+    const li = document.createElement('li');
+    li.className = 'list-group-item d-flex justify-content-between align-items-center';
+    li.textContent = c;
+    const btn = document.createElement('button');
+    btn.className = 'btn btn-sm btn-danger';
+    btn.textContent = 'Rimuovi';
+    btn.onclick = () => {
+      clubList.splice(idx, 1);
+      renderClubList();
+    };
+    li.appendChild(btn);
+    ul.appendChild(li);
+  });
+}
+
+window.addClub = function() {
+  const input = document.getElementById('new-club');
+  const val = input.value.trim();
+  if (val && !clubList.includes(val)) {
+    clubList.push(val);
+    input.value = '';
+    renderClubList();
+  }
+}
+
+window.saveClubSettings = async function() {
+  if (!currentUid) return;
+  await saveClubs(currentUid, clubList);
+  alert('Lista bastoni salvata!');
 }

--- a/profile1.html
+++ b/profile1.html
@@ -26,6 +26,16 @@
 
       <button class="btn btn-success" onclick="saveProfile()">Salva Profilo</button>
     </div>
+
+    <h2 class="mt-2">I miei Bastoni</h2>
+    <div class="profile-section">
+      <label for="new-club">Nuovo Bastone:</label>
+      <input type="text" id="new-club" class="form-control" placeholder="Es. 7 Iron" />
+      <button class="btn btn-success mt-2" onclick="addClub()">Aggiungi</button>
+
+      <ul id="clubs-list" class="list-group mt-2"></ul>
+      <button class="btn btn-success mt-2" onclick="saveClubSettings()">Salva Bastoni</button>
+    </div>
   </main>
 
 <script src="navbar.js"></script>

--- a/userSettings.js
+++ b/userSettings.js
@@ -1,0 +1,29 @@
+import { doc, getDoc, setDoc } from "https://www.gstatic.com/firebasejs/9.23.0/firebase-firestore.js";
+import { initFirebase } from './firebase-config.js';
+import { clubs as defaultClubs } from './clubList.js';
+
+const { db } = initFirebase();
+
+export async function loadClubs(uid) {
+  if (!uid) return defaultClubs;
+  try {
+    const ref = doc(db, 'users', uid, 'settings', 'clubs');
+    const snap = await getDoc(ref);
+    if (snap.exists() && Array.isArray(snap.data().clubs)) {
+      return snap.data().clubs;
+    }
+  } catch (e) {
+    console.warn('Failed to load clubs', e);
+  }
+  return defaultClubs;
+}
+
+export async function saveClubs(uid, clubs) {
+  if (!uid) return;
+  try {
+    const ref = doc(db, 'users', uid, 'settings', 'clubs');
+    await setDoc(ref, { clubs }, { merge: true });
+  } catch (e) {
+    console.warn('Failed to save clubs', e);
+  }
+}


### PR DESCRIPTION
## Summary
- allow saving custom club lists per user
- fetch user club list in score entry and club stats pages
- add club management UI in profile page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6859b09210c0832ebd64fd521c5c8d65