### PR TITLE
Add copyable round links

### DIFF
--- a/stats.html
+++ b/stats.html
@@ -102,7 +102,7 @@
     <table id="rounds-table">
       <thead>
         <tr>
-          <th>Data</th><th>Campo</th><th>Format</th><th>Punteggio</th><th>Netto</th><th>Dettagli</th><th>Azione</th>
+          <th>Data</th><th>Campo</th><th>Format</th><th>Punteggio</th><th>Netto</th><th>Dettagli</th><th>Condividi</th><th>Azione</th>
         </tr>
       </thead>
       <tbody></tbody>

--- a/stats.js
+++ b/stats.js
@@ -147,12 +147,16 @@ function drawTable(rounds){
       <td>${r.score}</td>
       <td>${netto !== '' ? (netto >= 0 ? '+' + netto : netto) : ''}</td>
       <td><a href="round.html?id=${r.id}">Dettagli</a></td>
+      <td><button class="copy-link" data-id="${r.id}">Copia link</button></td>
       <td><button class="delete-round" data-id="${r.id}">Elimina</button></td>
     `;
     tbody.appendChild(tr);
   });
   tbody.querySelectorAll('.delete-round').forEach(btn => {
     btn.addEventListener('click', () => deleteRound(btn.dataset.id));
+  });
+  tbody.querySelectorAll('.copy-link').forEach(btn => {
+    btn.addEventListener('click', () => copyRoundLink(btn.dataset.id));
   });
 }
 
@@ -289,6 +293,19 @@ async function deleteRound(id){
   if(!confirm('Eliminare il round?')) return;
   await deleteDoc(doc(db, 'golf_rounds', id));
   await loadStats();
+}
+
+function copyRoundLink(id){
+  const url = `${window.location.origin}/round.html?id=${id}`;
+  if(navigator.clipboard && window.isSecureContext){
+    navigator.clipboard.writeText(url).then(() => {
+      alert('Link copiato negli appunti');
+    }).catch(() => {
+      prompt('Copia il link:', url);
+    });
+  } else {
+    prompt('Copia il link:', url);
+  }
 }
 
 function drawCharts(rounds, validRounds){


### PR DESCRIPTION
## Summary
- make the rounds table show a "Condividi" column
- add a button to copy round links to clipboard

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6859ba667c3c832eaffd970fae1409d6