### PR TITLE
Add multi-player scoring

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,8 +14,8 @@
 
   <main class="container">
   <form id="start-round" class="form-container">
-    <label for="player">Il tuo nome:</label>
-    <input type="text" id="player" class="form-control" />
+    <label for="players">Giocatori (separati da virgola):</label>
+    <input type="text" id="players" class="form-control" />
 
     <label for="course">Nome del campo (scrivi per cercare):</label>
     <input type="text" id="course" class="form-control" list="course-options" oninput="filterCourseOptions()" />
@@ -76,6 +76,7 @@
       <input type="number" id="distance-input-0" class="distance-input form-control" />
     </div>
   </div>
+  <div id="additional-player-scores"></div>
     <button type="button" id="add-shot-btn" class="btn btn-success">Aggiungi colpo</button>
 
     <button type="button" class="btn btn-success" onclick="saveHole()">Salva Buca</button>

--- a/round.js
+++ b/round.js
@@ -25,12 +25,27 @@ async function loadRound() {
   const info = document.getElementById("round-info");
   info.innerHTML = `
     <p><strong>Campo:</strong> ${escapeHTML(data.course)}</p>
-    <p><strong>Giocatore:</strong> ${escapeHTML(data.player)}</p>
+    ${data.players ? '' : `<p><strong>Giocatore:</strong> ${escapeHTML(data.player)}</p>`}
     <p id="round-notes"><strong>Note:</strong> ${escapeHTML(data.notes || "—")}</p>
     <h2>Buche</h2>
   `;
 
-  data.holes.forEach(hole => {
+  if(data.players){
+    const leaderboard = document.createElement('div');
+    leaderboard.innerHTML = '<h3>Leaderboard</h3>';
+    const ul = document.createElement('ul');
+    data.players.forEach(p => {
+      const total = (p.holes || []).reduce((a,h)=>a+(h.score||0),0);
+      const li = document.createElement('li');
+      li.textContent = `${p.name}: ${total}`;
+      ul.appendChild(li);
+    });
+    leaderboard.appendChild(ul);
+    info.appendChild(leaderboard);
+  }
+
+  const holes = data.holes || (data.players && data.players[0]?.holes) || [];
+  holes.forEach(hole => {
     const div = document.createElement("div");
     div.className = "hole";
     const shots = (hole.shots && hole.shots.length)


### PR DESCRIPTION
## Summary
- allow entering multiple player names when starting a round
- capture per-player scores and store them in Firestore
- show a leaderboard of players when viewing a saved round

## Testing
- `node --check app.js`
- `node --check round.js`

------
https://chatgpt.com/codex/tasks/task_e_6859ba2552f8832ebca4b6a074e3e909