### PR TITLE
Add strokes gained analysis

### DIFF
--- a/stats.html
+++ b/stats.html
@@ -88,6 +88,7 @@
             <th>Distanza media (m)</th>
             <th>Distanza max (m)</th>
             <th>Distanza min (m)</th>
+            <th>SG medio</th>
           </tr>
         </thead>
         <tbody></tbody>


### PR DESCRIPTION
## Summary
- compute strokes gained per club from round data
- show average SG in club stats table

## Testing
- `node --check stats.js`

------
https://chatgpt.com/codex/tasks/task_e_6859bc7d8e5c832eafc70686e8b352d1