### PR TITLE
Add friend list feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,12 @@ navigation links.
   navigation to the rest of the app.
 - **index.html** – start a new round. Select a course and record scores for each
   hole; the data is saved to Firestore when the round is completed.
-- **stats.html** – view personal statistics such as handicap calculation, score
-  history and club statistics. Data is loaded from Firestore.
+- **stats.html** – view personal statistics or those of a friend using
+  `?uid=<id>`; shows handicap history and club statistics loaded from Firestore.
 - **clubs.html** – record individual club shots and see average distances for
   each club.
-- **profile1.html** – manage your personal profile information stored in
-  Firestore.
+- **profile1.html** – manage your profile, clubs and your list of friends stored
+  in Firestore.
 - **round.html** – display the details of a saved round.
 - **admin.html** – create or edit course definitions stored in Firestore.
 

--- a/profile.js
+++ b/profile.js
@@ -1,5 +1,12 @@
 import { onAuthStateChanged } from "https://www.gstatic.com/firebasejs/9.23.0/firebase-auth.js";
-import { doc, getDoc, setDoc } from "https://www.gstatic.com/firebasejs/9.23.0/firebase-firestore.js";
+import {
+  doc,
+  getDoc,
+  setDoc,
+  collection,
+  getDocs,
+  deleteDoc
+} from "https://www.gstatic.com/firebasejs/9.23.0/firebase-firestore.js";
 import { initFirebase } from './firebase-config.js';
 import { loadClubs, saveClubs } from './userSettings.js';
 import { clubs as defaultClubs } from './clubList.js';
@@ -7,6 +14,7 @@ import { clubs as defaultClubs } from './clubList.js';
 const { auth, db } = initFirebase();
 let currentUid = null;
 let clubList = [...defaultClubs];
+let friendList = [];
 
 onAuthStateChanged(auth, async (user) => {
   if (!user) {
@@ -27,6 +35,7 @@ onAuthStateChanged(auth, async (user) => {
 
   clubList = await loadClubs(currentUid);
   renderClubList();
+  await loadFriends();
 });
 
 window.saveProfile = async function () {
@@ -83,4 +92,52 @@ window.saveClubSettings = async function() {
   if (!currentUid) return;
   await saveClubs(currentUid, clubList);
   alert('Lista bastoni salvata!');
+}
+
+async function loadFriends(){
+  if(!currentUid) return;
+  const q = collection(db, 'users', currentUid, 'friends');
+  const snap = await getDocs(q);
+  friendList = snap.docs.map(d => ({ id: d.id, ...d.data() }));
+  renderFriendList();
+}
+
+function renderFriendList(){
+  const ul = document.getElementById('friends-list');
+  if(!ul) return;
+  ul.innerHTML = '';
+  friendList.forEach(f => {
+    const li = document.createElement('li');
+    li.className = 'list-group-item d-flex justify-content-between align-items-center';
+    li.textContent = f.id;
+    const actions = document.createElement('div');
+    const view = document.createElement('a');
+    view.className = 'btn btn-sm btn-primary me-2';
+    view.textContent = 'Vedi';
+    view.href = `stats.html?uid=${f.id}`;
+    const del = document.createElement('button');
+    del.className = 'btn btn-sm btn-danger';
+    del.textContent = 'Rimuovi';
+    del.onclick = () => removeFriend(f.id);
+    actions.appendChild(view);
+    actions.appendChild(del);
+    li.appendChild(actions);
+    ul.appendChild(li);
+  });
+}
+
+window.addFriend = async function(){
+  const input = document.getElementById('friend-uid');
+  const val = input.value.trim();
+  if(!val || friendList.some(f => f.id === val)) return;
+  await setDoc(doc(db, 'users', currentUid, 'friends', val), { since: new Date().toISOString() });
+  friendList.push({ id: val });
+  input.value = '';
+  renderFriendList();
+}
+
+window.removeFriend = async function(uid){
+  await deleteDoc(doc(db, 'users', currentUid, 'friends', uid));
+  friendList = friendList.filter(f => f.id !== uid);
+  renderFriendList();
 }

--- a/profile1.html
+++ b/profile1.html
@@ -36,6 +36,14 @@
       <ul id="clubs-list" class="list-group mt-2"></ul>
       <button class="btn btn-success mt-2" onclick="saveClubSettings()">Salva Bastoni</button>
     </div>
+
+    <h2 class="mt-2">I miei Amici</h2>
+    <div class="profile-section">
+      <label for="friend-uid">UID Amico:</label>
+      <input type="text" id="friend-uid" class="form-control" placeholder="UID amico" />
+      <button class="btn btn-success mt-2" onclick="addFriend()">Aggiungi</button>
+      <ul id="friends-list" class="list-group mt-2"></ul>
+    </div>
   </main>
 
 <script src="navbar.js"></script>

--- a/stats.html
+++ b/stats.html
@@ -10,7 +10,7 @@
 </head>
 <body class="stats-page">
   <header>
-    <h1>Statistiche Personali</h1>
+    <h1 id="stats-title">Statistiche Personali</h1>
   </header>
 
   <main class="container">


### PR DESCRIPTION
## Summary
- manage a friends subcollection under each user
- add friends section on the profile page
- allow viewing a friend's stats via query string
- document updated functionality

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6859bcd518ac832eb7e5bf3f8db6075b