### PR TITLE
Add multi-player step tracking

### DIFF
--- a/clubList.js
+++ b/clubList.js
@@ -11,5 +11,6 @@ export const clubs = [
   "9 Iron",
   "Pitching Wedge",
   "Sand Wedge",
-  "Lob Wedge"
+  "Lob Wedge",
+  "Putter"
 ];

--- a/index.html
+++ b/index.html
@@ -65,6 +65,8 @@
 
   <div id="hole-input" class="form-container">
     <h2>Buca <span id="hole-number">1</span></h2>
+    <label for="player-select">Giocatore:</label>
+    <select id="player-select" class="form-select"></select>
     <label for="par">Par:</label>
     <input type="number" id="par" class="form-control" />
 
@@ -100,10 +102,9 @@
       <input type="number" id="distance-input-0" class="distance-input form-control" />
     </div>
   </div>
-  <div id="additional-player-scores"></div>
-    <button type="button" id="add-shot-btn" class="btn btn-success">Aggiungi colpo</button>
+    <button type="button" id="add-shot-btn" class="btn btn-success">Registra colpo</button>
 
-    <button type="button" class="btn btn-success" onclick="saveHole()">Salva Buca</button>
+    <button type="button" class="btn btn-success" onclick="saveHole()">Prossima buca</button>
   </div>
   </main>
 


### PR DESCRIPTION
## Summary
- include putter in the default club list
- allow selecting the active player while recording a hole
- store shot information per player and switch between them
- compute scores for every player on "next hole"

## Testing
- `node --check app.js`
- `node --check clubList.js`


------
https://chatgpt.com/codex/tasks/task_e_6859cd5f143c832ea31122d331080a74