### PR TITLE
Add admin role gating and link in navbar

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -30,7 +30,7 @@
     <ul id="course-list"></ul>
   </main>
 
-<script src="navbar.js"></script>
+<script type="module" src="navbar.js"></script>
   <script type="module" src="admin.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 </body>

--- a/admin.js
+++ b/admin.js
@@ -7,6 +7,7 @@ import {
 } from 'https://www.gstatic.com/firebasejs/9.23.0/firebase-firestore.js';
 import { onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/9.23.0/firebase-auth.js';
 import { initFirebase } from './firebase-config.js';
+import { isAdmin } from './roles.js';
 
 const { auth, db } = initFirebase();
 let editingId = null;
@@ -66,7 +67,7 @@ window.saveCourse = async function () {
 };
 
 onAuthStateChanged(auth, user => {
-  if (!user) {
+  if (!isAdmin(user)) {
     window.location.href = 'home.html';
   } else {
     loadCourses();

--- a/clubs.html
+++ b/clubs.html
@@ -41,7 +41,7 @@
     </div>
   </main>
 
-<script src="navbar.js"></script>
+<script type="module" src="navbar.js"></script>
   <script type="module" src="clubs.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 </body>

--- a/home.html
+++ b/home.html
@@ -22,7 +22,7 @@
     </div>
   </main>
 
-  <script src="navbar.js"></script>
+  <script type="module" src="navbar.js"></script>
   <script type="module" src="home.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 </body>

--- a/index.html
+++ b/index.html
@@ -114,7 +114,7 @@
   </div>
   </main>
 
-<script src="navbar.js"></script>
+<script type="module" src="navbar.js"></script>
   <script type="module" src="src/js/roundState.js"></script>
   <script type="module" src="src/js/firebasePersistence.js"></script>
   <script type="module" src="src/js/ui.js"></script>

--- a/navbar.js
+++ b/navbar.js
@@ -1,4 +1,9 @@
 // navbar.js - injects navigation bar into each page
+import { onAuthStateChanged } from 'https://www.gstatic.com/firebasejs/9.23.0/firebase-auth.js';
+import { initFirebase } from './firebase-config.js';
+import { isAdmin } from './roles.js';
+
+const { auth } = initFirebase();
 
 document.addEventListener('DOMContentLoaded', () => {
   const nav = document.createElement('nav');
@@ -27,4 +32,15 @@ document.addEventListener('DOMContentLoaded', () => {
   } else {
     document.body.prepend(nav);
   }
+
+  const linksContainer = nav.querySelector('.navbar-nav');
+  const adminLink = document.createElement('a');
+  adminLink.className = 'nav-link';
+  adminLink.href = 'admin.html';
+  adminLink.textContent = '🛠️ Admin';
+  onAuthStateChanged(auth, user => {
+    if (isAdmin(user)) {
+      linksContainer.appendChild(adminLink);
+    }
+  });
 });

--- a/profile1.html
+++ b/profile1.html
@@ -49,7 +49,7 @@
     </div>
   </main>
 
-<script src="navbar.js"></script>
+<script type="module" src="navbar.js"></script>
   <script type="module" src="profile.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 </body>

--- a/roles.js
+++ b/roles.js
@@ -1,0 +1,5 @@
+// List of user email addresses allowed to access admin features
+export const ADMIN_EMAILS = ['admin@example.com'];
+export function isAdmin(user) {
+  return !!(user && ADMIN_EMAILS.includes(user.email));
+}

--- a/round.html
+++ b/round.html
@@ -18,7 +18,7 @@
   <div id="round-actions"></div>
 
 
-<script src="navbar.js"></script>
+<script type="module" src="navbar.js"></script>
   <script type="module" src="round.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 </body>

--- a/search.html
+++ b/search.html
@@ -25,7 +25,7 @@
       <ul id="course-results" class="list-group mt-2"></ul>
     </section>
   </main>
-  <script src="navbar.js"></script>
+  <script type="module" src="navbar.js"></script>
   <script type="module" src="search.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 </body>

--- a/stats.html
+++ b/stats.html
@@ -117,7 +117,7 @@
  
   </main>
 
-<script src="navbar.js"></script>
+<script type="module" src="navbar.js"></script>
   <script type="module" src="stats.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- restrict `admin.html` to users whose email is in `ADMIN_EMAILS`
- add `roles.js` with helper to check admin users
- show Admin link in navbar only for admin users
- load `navbar.js` as an ES module on all pages

## Testing
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_685a58fe44d0832e89806b593a7a75eb