### PR TITLE
Check admin role from Firestore

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,12 @@ The top navigation links are injected by `navbar.js`. Add the script tag below t
 ```
 
 This automatically inserts a Bootstrap styled navigation bar so you don't have to repeat the markup in each file.
+
+## Admin Users
+
+Authorized administrators are stored in a Firestore collection called
+`adminUsers`. Each document's ID should be the email address of an admin user.
+If the collection does not exist yet, create it in the Firestore console and
+add a document with the email of any current admin (for example
+`l.m.devirgilio@gmail.com`). The application falls back to this email list if
+the collection cannot be read.

--- a/admin.js
+++ b/admin.js
@@ -66,8 +66,8 @@ window.saveCourse = async function () {
   await loadCourses();
 };
 
-onAuthStateChanged(auth, user => {
-  if (!isAdmin(user)) {
+onAuthStateChanged(auth, async user => {
+  if (!(await isAdmin(user))) {
     window.location.href = 'home.html';
   } else {
     loadCourses();

--- a/navbar.js
+++ b/navbar.js
@@ -38,8 +38,8 @@ document.addEventListener('DOMContentLoaded', () => {
   adminLink.className = 'nav-link';
   adminLink.href = 'admin.html';
   adminLink.textContent = '🛠️ Admin';
-  onAuthStateChanged(auth, user => {
-    if (isAdmin(user)) {
+  onAuthStateChanged(auth, async user => {
+    if (await isAdmin(user)) {
       linksContainer.appendChild(adminLink);
     }
   });

--- a/roles.js
+++ b/roles.js
@@ -1,5 +1,24 @@
-// List of user email addresses allowed to access admin features
+// roles.js - determine if a user is allowed to access admin features
+import { doc, getDoc } from 'https://www.gstatic.com/firebasejs/9.23.0/firebase-firestore.js';
+import { initFirebase } from './firebase-config.js';
+
+// Fallback list of admin emails in case the Firestore collection is missing
 export const ADMIN_EMAILS = ['l.m.devirgilio@gmail.com'];
-export function isAdmin(user) {
-  return !!(user && ADMIN_EMAILS.includes(user.email));
+
+const { db } = initFirebase();
+
+// Returns a Promise that resolves to true if the user is an admin.
+// It first checks the `adminUsers` Firestore collection. If the collection or
+// document doesn't exist, it falls back to the ADMIN_EMAILS list.
+export async function isAdmin(user) {
+  if (!user) return false;
+  try {
+    const snap = await getDoc(doc(db, 'adminUsers', user.email));
+    if (snap.exists()) {
+      return true;
+    }
+  } catch (err) {
+    console.error('Error checking admin status:', err);
+  }
+  return ADMIN_EMAILS.includes(user.email);
 }


### PR DESCRIPTION
## Summary
- fetch admin list from the new `adminUsers` Firestore collection
- show the admin link only for admins fetched from Firestore
- gate `admin.html` behind the Firestore-based admin check
- document how to create and use the `adminUsers` collection

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685a5e4dde2c832e935251871cb41fde