### PR TITLE
Use env file for Firebase config

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,19 +22,20 @@ The pages include [Bootstrap](https://getbootstrap.com/) from a CDN for modern s
 
 1. Create a Firebase project with Authentication and Firestore enabled.
 2. Obtain your project configuration (apiKey, authDomain, projectId, etc.).
-3. Edit `firebase-config.js` and replace the placeholder configuration with your
-   own credentials.
+3. Create a `.env` file in the project root containing the credentials:
 
-```javascript
-export const firebaseConfig = {
-  apiKey: "<YOUR-API-KEY>",
-  authDomain: "<YOUR-PROJECT>.firebaseapp.com",
-  projectId: "<YOUR-PROJECT>",
-  storageBucket: "<YOUR-PROJECT>.appspot.com",
-  messagingSenderId: "<SENDER-ID>",
-  appId: "<APP-ID>"
-};
+```ini
+FIREBASE_API_KEY=<YOUR-API-KEY>
+FIREBASE_AUTH_DOMAIN=<YOUR-PROJECT>.firebaseapp.com
+FIREBASE_PROJECT_ID=<YOUR-PROJECT>
+FIREBASE_STORAGE_BUCKET=<YOUR-PROJECT>.appspot.com
+FIREBASE_MESSAGING_SENDER_ID=<SENDER-ID>
+FIREBASE_APP_ID=<APP-ID>
+FIREBASE_MEASUREMENT_ID=<MEASUREMENT-ID>
 ```
+
+The `.env` file is ignored by Git. `firebase-config.js` loads these values at
+runtime using a small helper so you don't have to commit your secrets.
 
 ## Running the app
 

--- a/env.js
+++ b/env.js
@@ -1,0 +1,24 @@
+// env.js - simple helper to load variables from a .env file synchronously
+export function loadEnv(path = '.env') {
+  const env = {};
+  try {
+    const xhr = new XMLHttpRequest();
+    xhr.open('GET', path, false); // synchronous request
+    xhr.send(null);
+    if (xhr.status === 200) {
+      const lines = xhr.responseText.split(/\n/);
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed || trimmed.startsWith('#')) continue;
+        const eq = trimmed.indexOf('=');
+        if (eq === -1) continue;
+        const key = trimmed.slice(0, eq).trim();
+        const value = trimmed.slice(eq + 1).trim();
+        env[key] = value;
+      }
+    }
+  } catch (e) {
+    console.warn('Failed to load', path, e);
+  }
+  return env;
+}

--- a/firebase-config.js
+++ b/firebase-config.js
@@ -1,15 +1,18 @@
 import { initializeApp, getApps } from "https://www.gstatic.com/firebasejs/9.23.0/firebase-app.js";
 import { getAuth } from "https://www.gstatic.com/firebasejs/9.23.0/firebase-auth.js";
 import { getFirestore } from "https://www.gstatic.com/firebasejs/9.23.0/firebase-firestore.js";
+import { loadEnv } from './env.js';
+
+const env = loadEnv();
 
 export const firebaseConfig = {
-  apiKey: "AIzaSyC2SWQzBCq2M18idSSXS-gR75I7fSV2NXk",
-  authDomain: "golfcaddy-ec421.firebaseapp.com",
-  projectId: "golfcaddy-ec421",
-  storageBucket: "golfcaddy-ec421.appspot.com",
-  messagingSenderId: "497160592489",
-  appId: "1:497160592489:web:548701ab6d395e579456f8",
-  measurementId: "G-XGBVHR0BD5"
+  apiKey: env.FIREBASE_API_KEY,
+  authDomain: env.FIREBASE_AUTH_DOMAIN,
+  projectId: env.FIREBASE_PROJECT_ID,
+  storageBucket: env.FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: env.FIREBASE_MESSAGING_SENDER_ID,
+  appId: env.FIREBASE_APP_ID,
+  measurementId: env.FIREBASE_MEASUREMENT_ID
 };
 
 export function initFirebase() {


### PR DESCRIPTION
## Summary
- load Firebase credentials from a `.env` file using a helper
- document new `.env` based setup
- add ignored `.env` file with Firebase credentials

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685a5e11ab98832e9c892c1cbd78d223