### PR TITLE
Improve accessibility and responsive styles

### DIFF
--- a/round.html
+++ b/round.html
@@ -12,10 +12,13 @@
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body class="round-page">
-
-  <h1>Dettagli Round</h1>
-  <div id="round-info"></div>
-  <div id="round-actions"></div>
+  <header class="page-header">
+    <h1>Dettagli Round</h1>
+  </header>
+  <main class="container">
+    <div id="round-info" aria-live="polite"></div>
+    <div id="round-actions"></div>
+  </main>
 
 
   <script type="module" src="entries/round.js"></script>

--- a/search.html
+++ b/search.html
@@ -14,13 +14,15 @@
   <main class="container">
     <section>
       <h2>Cerca Utenti</h2>
-      <input type="text" id="search-user-input" class="form-control" placeholder="Nome o Email" />
+      <label for="search-user-input" class="visually-hidden">Nome o Email</label>
+      <input type="text" id="search-user-input" class="form-control" placeholder="Nome o Email" aria-label="Nome o Email" />
       <button class="btn btn-success mt-2" onclick="searchUsers()">Cerca</button>
       <ul id="user-results" class="list-group mt-2"></ul>
     </section>
     <section class="mt-4">
       <h2>Cerca Campi da Golf</h2>
-      <input type="text" id="search-course-input" class="form-control" placeholder="Nome del campo" />
+      <label for="search-course-input" class="visually-hidden">Nome del campo</label>
+      <input type="text" id="search-course-input" class="form-control" placeholder="Nome del campo" aria-label="Nome del campo" />
       <button class="btn btn-success mt-2" onclick="searchCourses()">Cerca</button>
       <ul id="course-results" class="list-group mt-2"></ul>
     </section>

--- a/statsRender.js
+++ b/statsRender.js
@@ -1,6 +1,6 @@
 const styleVars = getComputedStyle(document.documentElement);
 export const CHART_COLORS = {
-  distance: styleVars.getPropertyValue('--accent-color').trim() || '#4682B4',
+  distance: styleVars.getPropertyValue('--accent-color').trim() || '#0d6efd',
   putt: styleVars.getPropertyValue('--chart-putt-color').trim() || '#32CD32',
   bar18: styleVars.getPropertyValue('--chart-18-color').trim() || '#006400',
   bar9: styleVars.getPropertyValue('--chart-9-color').trim() || '#32CD32',

--- a/styles.css
+++ b/styles.css
@@ -3,9 +3,9 @@
 :root {
     --primary-color: #006400;
     --nav-bg: #ffffff;
-    --accent-color: #4682B4;
+    --accent-color: #0d6efd;
     --background-color: #fff;
-    --text-color: #333;
+    --text-color: #212529;
     --chart-putt-color: #32CD32;
     --chart-18-color: #006400;
     --chart-9-color: #32CD32;
@@ -144,6 +144,13 @@ textarea {
     flex: 1;
 }
 
+@media (max-width: 600px) {
+    .shot-row {
+        flex-direction: column;
+        align-items: stretch;
+    }
+}
+
 #hole-input {
     display: none;
 }
@@ -204,6 +211,12 @@ th, td {
 .filter-section {
     max-width: 800px;
     margin: 2rem auto;
+}
+
+@media (max-width: 600px) {
+    .filter-section {
+        margin: 1rem;
+    }
 }
 
 .scroll-x {


### PR DESCRIPTION
## Summary
- tweak CSS colors for better contrast
- add mobile breakpoints for shot rows and filters
- add semantic structure to `round.html`
- provide hidden labels for search inputs
- update chart color fallback to match new accent color

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a884bc78c832eba235bafb48add93