### PR TITLE
Add manifest and service worker

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -7,7 +7,7 @@
    <link rel="apple-touch-icon" href="favicon/apple-touch-icon.png">
   <link rel="icon" type="image/png" sizes="32x32" href="favicon/favicon-32x32.png">
   <link rel="icon" type="image/png" sizes="16x16" href="favicon/favicon-16x16.png">
-  <link rel="manifest" href="favicon/site.webmanifest">
+  <link rel="manifest" href="manifest.json">
   <title>Gestione Campi</title>
   <link rel="stylesheet" href="styles.css" />
 </head>

--- a/clubs.html
+++ b/clubs.html
@@ -7,7 +7,7 @@
    <link rel="apple-touch-icon" href="favicon/apple-touch-icon.png">
   <link rel="icon" type="image/png" sizes="32x32" href="favicon/favicon-32x32.png">
   <link rel="icon" type="image/png" sizes="16x16" href="favicon/favicon-16x16.png">
-  <link rel="manifest" href="favicon/site.webmanifest">
+  <link rel="manifest" href="manifest.json">
   <title>Statistiche Bastoni - Pro Putt</title>
   <link rel="stylesheet" href="styles.css" />
 </head>

--- a/home.html
+++ b/home.html
@@ -4,6 +4,10 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
+  <link rel="apple-touch-icon" href="favicon/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="favicon/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="favicon/favicon-16x16.png">
+  <link rel="manifest" href="manifest.json">
   <title>Pro Putt - Home</title>
   <link rel="stylesheet" href="styles.css" />
 </head>

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <link rel="apple-touch-icon" href="favicon/apple-touch-icon.png">
   <link rel="icon" type="image/png" sizes="32x32" href="favicon/favicon-32x32.png">
   <link rel="icon" type="image/png" sizes="16x16" href="favicon/favicon-16x16.png">
-  <link rel="manifest" href="favicon/site.webmanifest">
+  <link rel="manifest" href="manifest.json">
   <title>Aggiungi Round - Pro Putt</title>
   <link rel="stylesheet" href="styles.css" />
 </head>

--- a/navbar.js
+++ b/navbar.js
@@ -38,9 +38,15 @@ document.addEventListener('DOMContentLoaded', () => {
   adminLink.className = 'nav-link';
   adminLink.href = 'admin.html';
   adminLink.textContent = '🛠️ Admin';
-  onAuthStateChanged(auth, async user => {
+onAuthStateChanged(auth, async user => {
     if (await isAdmin(user)) {
       linksContainer.appendChild(adminLink);
     }
   });
 });
+
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('service-worker.js');
+  });
+}

--- a/profile1.html
+++ b/profile1.html
@@ -7,7 +7,7 @@
   <link rel="apple-touch-icon" href="favicon/apple-touch-icon.png">
   <link rel="icon" type="image/png" sizes="32x32" href="favicon/favicon-32x32.png">
   <link rel="icon" type="image/png" sizes="16x16" href="favicon/favicon-16x16.png">
-  <link rel="manifest" href="favicon/site.webmanifest">
+  <link rel="manifest" href="manifest.json">
   <title>Pro Putt - Il mio Profilo</title>
   <link rel="stylesheet" href="styles.css" />
 </head>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,20 @@
+{
+  "name": "Pro Putt",
+  "short_name": "ProPutt",
+  "start_url": "/home.html",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#ffffff",
+  "icons": [
+    {
+      "src": "favicon/android-chrome-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "favicon/android-chrome-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
+}

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,0 +1,41 @@
+const CACHE_NAME = 'golfcaddy-cache-v1';
+const ASSETS = [
+  '/',
+  '/home.html',
+  '/index.html',
+  '/clubs.html',
+  '/search.html',
+  '/round.html',
+  '/profile1.html',
+  '/stats.html',
+  '/admin.html',
+  '/styles.css',
+  '/manifest.json',
+  '/favicon/android-chrome-192x192.png',
+  '/favicon/android-chrome-512x512.png',
+  '/favicon/favicon-32x32.png',
+  '/favicon/favicon-16x16.png'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME)
+      .then(cache => cache.addAll(ASSETS))
+      .then(() => self.skipWaiting())
+  );
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys =>
+      Promise.all(keys.filter(key => key !== CACHE_NAME).map(key => caches.delete(key)))
+    ).then(() => self.clients.claim())
+  );
+});
+
+self.addEventListener('fetch', event => {
+  if (event.request.method !== 'GET') return;
+  event.respondWith(
+    caches.match(event.request).then(resp => resp || fetch(event.request))
+  );
+});

--- a/round.html
+++ b/round.html
@@ -7,7 +7,7 @@
   <link rel="apple-touch-icon" href="favicon/apple-touch-icon.png">
   <link rel="icon" type="image/png" sizes="32x32" href="favicon/favicon-32x32.png">
   <link rel="icon" type="image/png" sizes="16x16" href="favicon/favicon-16x16.png">
-  <link rel="manifest" href="favicon/site.webmanifest">
+  <link rel="manifest" href="manifest.json">
   <title>Dettagli Round</title>
   <link rel="stylesheet" href="styles.css" />
 </head>

--- a/search.html
+++ b/search.html
@@ -4,6 +4,10 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css">
+  <link rel="apple-touch-icon" href="favicon/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="favicon/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="favicon/favicon-16x16.png">
+  <link rel="manifest" href="manifest.json">
   <title>Pro Putt - Cerca</title>
   <link rel="stylesheet" href="styles.css" />
 </head>

--- a/stats.html
+++ b/stats.html
@@ -7,7 +7,7 @@
   <link rel="apple-touch-icon" href="favicon/apple-touch-icon.png">
   <link rel="icon" type="image/png" sizes="32x32" href="favicon/favicon-32x32.png">
   <link rel="icon" type="image/png" sizes="16x16" href="favicon/favicon-16x16.png">
-  <link rel="manifest" href="favicon/site.webmanifest">
+  <link rel="manifest" href="manifest.json">
   <title>Statistiche - Pro Putt</title>
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <link rel="stylesheet" href="styles.css" />


### PR DESCRIPTION
## Summary
- add `manifest.json` under `public/`
- implement `service-worker.js` for offline caching
- register service worker in `navbar.js`
- reference the manifest from all HTML pages

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685a88579b6c832e82264c4326384af5