### PR TITLE
Add trend metrics and visualizations

### DIFF
--- a/stats.html
+++ b/stats.html
@@ -77,6 +77,16 @@
   </section>
 
   <section class="chart-container">
+    <h2>Trend Netto Mobile</h2>
+    <canvas id="scoreTrendChart"></canvas>
+  </section>
+
+  <section class="chart-container">
+    <h2>Strokes Gained Totali</h2>
+    <canvas id="sgTrendChart"></canvas>
+  </section>
+
+  <section class="chart-container">
     <h2>Statistiche per Club</h2>
     <label for="club-filter">Filtra per club:</label>
     <select id="club-filter">

--- a/stats.js
+++ b/stats.js
@@ -5,7 +5,7 @@ if (!localStorage.getItem("uid")) {
 import { collection, getDocs, query, where, doc, deleteDoc, getDoc } from "https://www.gstatic.com/firebasejs/9.23.0/firebase-firestore.js";
 import { initFirebase } from './src/firebase-config.js';
 import { calculateHandicap } from './handicap.js';
-import { computeStrokesGained, aggregateClubStats, filterRounds, validHandicapRounds } from './statsCalc.js';
+import { computeStrokesGained, aggregateClubStats, filterRounds, validHandicapRounds, computeScoreTrend, computeRoundStrokesGained } from './statsCalc.js';
 import * as Render from './statsRender.js';
 
 const { db } = initFirebase();
@@ -80,9 +80,13 @@ function updateDisplay() {
 
   ({ clubAggregates, clubDistances } = aggregateClubStats(rounds, allShots));
   clubStrokes = computeStrokesGained(allRounds);
+  const scoreTrend = computeScoreTrend(rounds);
+  const sgTrend = computeRoundStrokesGained(rounds);
 
   Render.drawTable(rounds, viewingFriend, deleteRound, copyRoundLink);
   Render.drawCharts(rounds, validForHCP);
+  Render.drawScoreTrendChart(scoreTrend);
+  Render.drawSgChart(sgTrend);
   Render.drawParAverages(rounds);
   Render.updateClubStatsDisplay(clubAggregates, clubStrokes, document.getElementById('club-filter').value);
   Render.renderClubDistanceChart(clubDistances, document.getElementById('club-filter').value);

--- a/statsCalc.js
+++ b/statsCalc.js
@@ -107,3 +107,22 @@ export function validHandicapRounds(allRounds){
       par: r.par
     }));
 }
+
+export function computeScoreTrend(rounds, window=5){
+  const sorted = [...rounds].sort((a,b)=>a.date-b.date);
+  return sorted.map((r,i)=>{
+    const slice = sorted.slice(Math.max(0,i-window+1), i+1);
+    const avg = slice.reduce((s,x)=>s + (x.score - x.par),0) / slice.length;
+    return { date:r.date, avg };
+  });
+}
+
+export function computeRoundStrokesGained(rounds){
+  return rounds.map(r=>{
+    const sg = r.holes.reduce((tot,h)=>{
+      const dist = typeof h.distance === 'number' ? h.distance : 0;
+      return tot + (expectedStrokes(dist) - h.score);
+    },0);
+    return { date:r.date, sg };
+  });
+}

--- a/statsRender.js
+++ b/statsRender.js
@@ -6,10 +6,12 @@ export const CHART_COLORS = {
   bar9: styleVars.getPropertyValue('--chart-9-color').trim() || '#32CD32',
   hcp: styleVars.getPropertyValue('--chart-hcp-color').trim() || '#FFA500',
   fw: styleVars.getPropertyValue('--chart-fw-color').trim() || '#1E90FF',
-  gir: styleVars.getPropertyValue('--chart-gir-color').trim() || '#FF4500'
+  gir: styleVars.getPropertyValue('--chart-gir-color').trim() || '#FF4500',
+  trend: styleVars.getPropertyValue('--chart-trend-color').trim() || '#8A2BE2',
+  sg: styleVars.getPropertyValue('--chart-sg-color').trim() || '#FF1493'
 };
 
-let hcpChart, puttChart, clubDistanceChart, fwGirChart;
+let hcpChart, puttChart, clubDistanceChart, fwGirChart, scoreTrendChart, sgChart;
 
 export function populateCourseFilter(allRounds, filters, updateCallback){
   const sel = document.getElementById('filter-course');
@@ -184,6 +186,34 @@ export function drawFwGirChart(rounds){
       ]
     },
     options:{ scales:{ y:{ beginAtZero:true, max:100 } } }
+  });
+}
+
+export function drawScoreTrendChart(trend){
+  if(scoreTrendChart){
+    scoreTrendChart.destroy();
+    scoreTrendChart = null;
+  }
+  const labels = trend.map(t=>formatDate(t.date));
+  const data = trend.map(t=>t.avg.toFixed(2));
+  scoreTrendChart = new Chart(document.getElementById('scoreTrendChart'), {
+    type:'line',
+    data:{ labels, datasets:[{ label:'Media Mobile Netto', data, borderColor:CHART_COLORS.trend, fill:false }]},
+    options:{ scales:{ y:{ beginAtZero:false } } }
+  });
+}
+
+export function drawSgChart(dataArr){
+  if(sgChart){
+    sgChart.destroy();
+    sgChart = null;
+  }
+  const labels = dataArr.map(t=>formatDate(t.date));
+  const data = dataArr.map(t=>t.sg.toFixed(2));
+  sgChart = new Chart(document.getElementById('sgTrendChart'), {
+    type:'line',
+    data:{ labels, datasets:[{ label:'Strokes Gained', data, borderColor:CHART_COLORS.sg, fill:false }]},
+    options:{ scales:{ y:{ beginAtZero:false } } }
   });
 }
 

--- a/tests/statsCalc.test.js
+++ b/tests/statsCalc.test.js
@@ -1,4 +1,4 @@
-import { expectedStrokes, filterRounds } from '../statsCalc.js';
+import { expectedStrokes, filterRounds, computeScoreTrend, computeRoundStrokesGained } from '../statsCalc.js';
 
 describe('expectedStrokes', () => {
   test('returns base value for zero or negative distance', () => {
@@ -36,5 +36,29 @@ describe('filterRounds', () => {
     });
     expect(res).toHaveLength(1);
     expect(res[0].date).toEqual(new Date('2023-03-01'));
+  });
+});
+
+describe('computeScoreTrend', () => {
+  const rounds = [
+    { date: new Date('2023-01-01'), score: 40, par: 36 },
+    { date: new Date('2023-01-08'), score: 42, par: 36 },
+    { date: new Date('2023-01-15'), score: 41, par: 36 },
+    { date: new Date('2023-01-22'), score: 39, par: 36 }
+  ];
+  test('calculates moving average of net score', () => {
+    const res = computeScoreTrend(rounds, 2);
+    expect(res[1].avg).toBeCloseTo(5);
+    expect(res[3].avg).toBeCloseTo(4);
+  });
+});
+
+describe('computeRoundStrokesGained', () => {
+  const rounds = [
+    { date: new Date('2023-02-01'), holes:[{ distance:200, score:3 }] }
+  ];
+  test('returns strokes gained vs benchmark', () => {
+    const res = computeRoundStrokesGained(rounds);
+    expect(res[0].sg).toBeCloseTo(1);
   });
 });


### PR DESCRIPTION
## Summary
- implement score trends and per-round strokes gained in `statsCalc.js`
- plot score trend and strokes gained charts in `statsRender.js`
- display new charts in `stats.html`
- wire new calculations in `stats.js`
- test new utility functions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a88873fa4832e9229085f0a4e2672