### PR TITLE
Add graph descriptions and populate club filter

### DIFF
--- a/stats.html
+++ b/stats.html
@@ -82,11 +82,13 @@
 
   <section class="chart-container">
     <h2>Trend Netto Mobile</h2>
+    <div class="info-text">Media mobile del punteggio netto (score meno par) degli ultimi round.</div>
     <canvas id="scoreTrendChart"></canvas>
   </section>
 
   <section class="chart-container">
     <h2>Strokes Gained Totali</h2>
+    <div class="info-text">Andamento complessivo degli strokes gained ottenuti in ogni round.</div>
     <canvas id="sgTrendChart"></canvas>
   </section>
 

--- a/stats.js
+++ b/stats.js
@@ -70,6 +70,20 @@ async function loadClubShots(){
   });
 }
 
+function populateClubFilterOptions(clubs){
+  const sel = document.getElementById('club-filter');
+  if(!sel) return;
+  const current = sel.value;
+  sel.innerHTML = '<option value="all">Tutti i club</option>';
+  Object.keys(clubs).sort().forEach(c => {
+    const opt = document.createElement('option');
+    opt.value = c;
+    opt.textContent = c;
+    sel.appendChild(opt);
+  });
+  if([...sel.options].some(o => o.value === current)) sel.value = current;
+}
+
 
 function updateDisplay() {
   const rounds = filterRounds(allRounds, filters);
@@ -82,6 +96,7 @@ function updateDisplay() {
   clubStrokes = computeStrokesGained(allRounds);
   const scoreTrend = computeScoreTrend(rounds);
   const sgTrend = computeRoundStrokesGained(rounds);
+  populateClubFilterOptions(clubAggregates);
 
   Render.drawTable(rounds, viewingFriend, deleteRound, copyRoundLink);
   Render.drawCharts(rounds, validForHCP);


### PR DESCRIPTION
## Summary
- explain score trend and SG graphs on stats page
- populate the club selection filter

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a9f01b9cc832eb275097fb4fc6254